### PR TITLE
`c_long` -> `int64` for `content_length`

### DIFF
--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -9,10 +9,10 @@ module http_response
 
     ! Response Type
     type :: response_type
-        character(len=:), public, allocatable :: url, content, method, err_msg, header_string
-        integer, public :: status_code = 0
-        integer(kind=int64), public :: content_length = 0
-        logical, public :: ok = .true.
+        character(len=:), allocatable :: url, content, method, err_msg, header_string
+        integer :: status_code = 0
+        integer(kind=int64) :: content_length = 0
+        logical :: ok = .true.
         type(fhash_tbl_t) :: header
     end type response_type
 

--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -11,7 +11,7 @@ module http_response
     type :: response_type
         character(len=:), public, allocatable :: url, content, method, err_msg, header_string
         integer, public :: status_code = 0
-        integer(kind=c_long), public :: content_length = 0
+        integer(kind=c_size_t), public :: content_length = 0
         logical, public :: ok = .true.
         type(fhash_tbl_t) :: header
     end type response_type

--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -1,5 +1,5 @@
 module http_response
-    use, intrinsic :: iso_c_binding, only : c_size_t
+    use, intrinsic :: iso_fortran_env, only: int64
     use fhash, only: fhash_tbl_t, key => fhash_key
 
     implicit none
@@ -11,7 +11,7 @@ module http_response
     type :: response_type
         character(len=:), public, allocatable :: url, content, method, err_msg, header_string
         integer, public :: status_code = 0
-        integer(kind=c_size_t), public :: content_length = 0
+        integer(kind=int64), public :: content_length = 0
         logical, public :: ok = .true.
         type(fhash_tbl_t) :: header
     end type response_type


### PR DESCRIPTION
#7 introduced a missing import which broke the build (a case for why we need tests #9 and CI next).

While adding it, I realized that `content_length` should be `c_size_t` instead of `c_long`. Probably no difference in practice, both seem to work, but I naively expect `c_size_t` to be more correct since content length is unsigned.