### PR TITLE
make headers more user friendly

### DIFF
--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -4,16 +4,21 @@ program response_header
     implicit none
     type(response_type) :: response
     type(string_type), allocatable :: headers(:)
+    character(:), allocatable :: val
     integer :: i = 0
 
-    response = request(url='https://gorest.co.in/public/v2/todos')
+    response = request(url='https://jsonplaceholder.typicode.com/todos/1')
     if(.not. response%ok) then
-        print *,"Error message : ", response%err_msg
+        print *,'Error message : ', response%err_msg
     else
+        print *, '===========Response header value by passing string_type============'
         headers = response%header_keys()
         do i = 1, size(headers)
-            print *,headers(i), ": ", response%header_value(headers(i))
+            print *, headers(i), ': ', response%header_value(headers(i))
         end do
+        print *, '===========Response header value by passing characters============'
+        val = response%header_value('date')
+        print *, 'date', ' : ',val
     end if
 
 end program response_header

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -1,25 +1,18 @@
 program response_header
-    use fhash, only: fhash_tbl_t, key => fhash_key, fhash_iter_t, fhash_key_t
+    use stdlib_string_type
     use http, only: response_type, request
     implicit none
-    
-    type(fhash_iter_t) :: iter
-    class(fhash_key_t), allocatable :: ikey
-    class(*), allocatable :: idata
     type(response_type) :: response
-    character(:), allocatable :: val
+    type(string_type), allocatable :: headers(:)
+    integer :: i = 0
 
     response = request(url='https://gorest.co.in/public/v2/todos')
     if(.not. response%ok) then
         print *,"Error message : ", response%err_msg
     else
-        print '(a)', '=================Response Header in string=================='
-        print '(a)',  response%header_string
-        print '(a)', '=================Response Header in hash table=============='
-        iter = fhash_iter_t(response%header)
-        do while(iter%next(ikey,idata))
-            call response%header%get(key(ikey%to_string()),val)
-            print '(a,": ",a)', ikey%to_string(), val
+        headers = response%header_keys()
+        do i = 1, size(headers)
+            print *,headers(i), ": ", response%header_value(headers(i))
         end do
     end if
 

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -1,13 +1,19 @@
 program response_header
     use stdlib_string_type
-    use http, only: response_type, request
+    use http, only: response_type, request, header_type
     implicit none
     type(response_type) :: response
     type(string_type), allocatable :: headers(:)
+    type(header_type) :: req_header
     character(:), allocatable :: val
     integer :: i = 0
 
-    response = request(url='https://jsonplaceholder.typicode.com/todos/1')
+    ! setting request header
+    call req_header%set_header('h1', 'v1')
+    call req_header%set_header('h2', 'v2')
+    call req_header%set_header('h3', 'v3')
+
+    response = request(url='https://jsonplaceholder.typicode.com/todos/1', header=req_header)
     if(.not. response%ok) then
         print *,'Error message : ', response%err_msg
     else
@@ -20,5 +26,4 @@ program response_header
         val = response%header_value('date')
         print *, 'date', ' : ',val
     end if
-
 end program response_header

--- a/fpm.toml
+++ b/fpm.toml
@@ -21,3 +21,4 @@ source-form = "free"
 [dependencies]
 fortran-curl = {git = "https://github.com/interkosmos/fortran-curl.git"}
 fhash = { git = "https://github.com/LKedward/fhash.git" }
+stdlib = "*"

--- a/src/http.f90
+++ b/src/http.f90
@@ -3,4 +3,5 @@ module http
         HTTP_DELETE, HTTP_GET, HTTP_HEAD, HTTP_PATCH, HTTP_POST, HTTP_POST
     use http_response, only: response_type
     use http_client, only: request
+    use http_header, only : header_type
 end module http

--- a/src/http/http_header.f90
+++ b/src/http/http_header.f90
@@ -1,0 +1,23 @@
+module http_header
+    use iso_c_binding
+    use curl
+    implicit none
+    private
+    public :: header_type
+    type :: header_type
+        type(c_ptr) :: header_list_ptr = c_null_ptr
+        integer :: header_count = 0
+    contains
+        procedure :: set_header
+    end type header_type
+contains
+    subroutine set_header(this, h_key, h_val)
+        class(header_type), intent(inout) :: this
+        character(*), intent(in) :: h_key, h_val
+        character(:), allocatable :: final_header_string
+
+        final_header_string = h_key // ':' // h_val // c_null_char
+        this%header_list_ptr = curl_slist_append(this%header_list_ptr, final_header_string)
+        this%header_count = this%header_count + 1
+    end subroutine set_header
+end module http_header

--- a/src/http/http_request.f90
+++ b/src/http/http_request.f90
@@ -1,4 +1,6 @@
 module http_request
+    use, intrinsic :: iso_c_binding
+    use http_header, only : header_type
     implicit none
 
     private
@@ -17,6 +19,7 @@ module http_request
     type :: request_type
         character(len=:), allocatable :: url
         integer :: method
+        type(header_type) :: header
     end type request_type
 
 end module http_request

--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -16,16 +16,18 @@ module http_response
         type(fhash_tbl_t), private :: header_fhash
         type(string_type), private, allocatable :: header_key(:)
         integer, private :: header_count = 0
- 
+        
     contains
         procedure :: set_header_key
         procedure :: header_keys
-        procedure :: header_value
+        procedure :: header_string_type_key
+        procedure :: header_char_key
+        generic :: header_value => header_string_type_key, header_char_key
         procedure :: update_header_fhash
     end type response_type
     
 contains
-
+    
     subroutine update_header_fhash(this, h_key, h_val)
         class(response_type), intent(inout) :: this
         character(:), intent(in), allocatable :: h_key, h_val
@@ -43,7 +45,7 @@ contains
         allocate(this%header_key(this%header_count))
         iter = fhash_iter_t(this%header_fhash)
         do while(iter%next(ikey,idata))
-            this%header_key(i) = ikey%to_string()
+            this%header_key(i) = trim(ikey%to_string())
             i = i + 1
         end do
     end subroutine set_header_key
@@ -54,7 +56,7 @@ contains
         header_keys = this%header_key
     end function header_keys
 
-    function header_value(this, h_key)
+    function header_string_type_key(this, h_key) result(header_value)
         class(response_type) :: this
         type(string_type) :: h_key
         character(:), allocatable :: header_value
@@ -63,6 +65,17 @@ contains
         else
             header_value = ''
         end if
-    end function header_value
+    end function header_string_type_key
+
+    function header_char_key(this, h_key) result(header_value)
+        class(response_type) :: this
+        character(*) :: h_key
+        character(:), allocatable :: header_value
+        if(len(h_key) /= 0) then
+            call this%header_fhash%get(key(h_key),header_value)
+        else
+            header_value = ''
+        end if
+    end function header_char_key
 
 end module http_response

--- a/test/test_get.f90
+++ b/test/test_get.f90
@@ -1,15 +1,13 @@
 program test_get
     use iso_fortran_env, only: stderr => error_unit
-    use fhash, only:  key => fhash_key, fhash_iter_t, fhash_key_t
+    use stdlib_string_type
     use http, only : response_type, request
     implicit none
     type(response_type) :: res
     character(:), allocatable :: msg, original_content
     logical :: ok = .true.
+    type(string_type), allocatable :: header_array(:)
 
-    type(fhash_iter_t) :: iter
-    class(fhash_key_t), allocatable :: ikey
-    class(*), allocatable :: idata
     integer :: header_counter = 0, original_header_count = 19
 
     original_content = '{"id":15726,"user_id":2382773,&
@@ -43,11 +41,8 @@ program test_get
         msg = msg // 'test case 3, '
     end if
 
-    iter = fhash_iter_t(res%header)
-    do while(iter%next(ikey,idata))
-        header_counter = header_counter + 1
-    end do
-
+    header_array = res%header_keys()
+    header_counter = size(header_array)
     if (header_counter /= original_header_count) then
         ok = .false.
         msg = msg // 'test case 4, '

--- a/test/test_get.f90
+++ b/test/test_get.f90
@@ -1,12 +1,13 @@
 program test_get
     use iso_fortran_env, only: stderr => error_unit
     use stdlib_string_type
-    use http, only : response_type, request
+    use http, only : response_type, request, header_type
     implicit none
     type(response_type) :: res
     character(:), allocatable :: msg, original_content
     logical :: ok = .true.
     type(string_type), allocatable :: header_array(:)
+    type(header_type) :: request_header
 
     integer :: header_counter = 0, original_header_count = 19
 
@@ -15,7 +16,13 @@ program test_get
     &"due_on":"2023-06-09T00:00:00.000+05:30",&
     &"status":"completed"}'
 
-    res = request(url='https://gorest.co.in/public/v2/todos/15726')
+    ! setting request header
+    call request_header%set_header('header-1', 'value-1')
+    call request_header%set_header('header-2', 'value-2')
+    call request_header%set_header('header-3', 'value-3')
+
+
+    res = request(url='https://gorest.co.in/public/v2/todos/15726', header=request_header)
     
     msg = 'test_get: '
     if (.not. res%ok) then


### PR DESCRIPTION
### Making Header access more [user friendly](https://github.com/fortran-lang/http-client/issues/11#issuecomment-1572283627) 
* Rename the `response_type` `header` to `header_fhash` and make it private.
* Remove the `header_string`, find it redundant
* Add stdlib as a dependency
* Add a private `header_key` property for storing the header key of type `string_type`.
* Added `header_keys()` procedure returning `header_key`
* Add `header_value(key)` procedure returning value of corresponding header key argument.
* Added `set_header_key` procedure, populate the `header_key` array.
* Update the tests and example files accordingly. 