### PR TITLE
Making Header access more user friendly and Performing all cURL related tasks in a single function or subroutine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,115 @@
-# http-client
+# **http**
+## **Overview**
 
-HTTP client library for Fortran
+The `http` Fortran package provides a **simple and convenient** way to make HTTP requests and retrieve responses. It aims to **simplify** the process of interacting with web services by providing a high-level API.
 
-## Getting started
+Currently package includes the following features:
 
-Get the code:
+* Sending `GET` request (`POST`, `PUT`, `DELETE`, and other HTTP requests coming soon).
+* Handling response data, including status code, content length, method, headers and content.
+* Support for custom headers and request parameters.
+* Error handling for unsuccessful requests.
 
+## **Prerequisites**
+Before building the library, ensure that you have the necessary dependencies installed. On `Ubuntu`, you need to install the curl development headers. Use the following command:
+```
+sudo apt install -y libcurl4-openssl-dev
+```
+## **fpm usage**
+To use `http` within your fpm project, add the following to your package manifest file (fpm.toml):
+```toml
+[dependencies]
+fhash = { git = "https://github.com/fortran-lang/http-client.git" }
+```
+## **Usage Example**
+The following example demonstrates how to use the http package to make a **Simple GET request** and process the response
+
+```fortran
+program simple_get
+    use http, only : response_type, request
+    implicit none
+    type(response_type) :: response
+
+    ! Send a GET request to retrieve JSON data
+    response = request(url='https://jsonplaceholder.typicode.com/todos/1')
+
+    ! Check if the request was successful
+    if (.not. response%ok) then
+        print *, 'Error message:', response%err_msg
+    else
+        ! Print the response details
+        print *, 'Response Code    :', response%status_code
+        print *, 'Response Length  :', response%content_length
+        print *, 'Response Method  :', response%method
+        print *, 'Response Content :', response%content
+    end if
+
+end program simple_get
+
+```
+### Ouptut : 
+```
+ Response Code    :          200
+ Response Length  :                    83
+ Response Method  : GET
+ Response Content : {
+  "userId": 1,
+  "id": 1,
+  "title": "delectus aut autem",
+  "completed": false
+}
+```
+In this example, we make a GET request to the URL https://jsonplaceholder.typicode.com/todos/1 to retrieve JSON data. If the request is successful, we print the ***response code, content length, method, and content***. If the request fails, we print the ***error message***.
+
+## **Contributing to project**
+Thank you for your interest in contributing to the `http` Fortran package! Contributions from the community are valuable in improving and enhancing the functionality of the package. This section provides a guide on how to get the code, build the library, and run examples and tests.
+
+### **Get the code**
+To get started, follow these steps:
+
+Clone the repository using Git:
 ```
 git clone https://github.com/fortran-lang/http-client
 cd http-client
 ```
-Install curl development headers on Ubuntu
+### **Prerequisites**
+Before building the library, ensure that you have the necessary dependencies installed. On `Ubuntu`, you need to install the curl development headers. Use the following command:
 ```
 sudo apt install -y libcurl4-openssl-dev
 ```
+### **Build the library**
 
-Build the library using [fpm](https://fpm.fortran-lang.org).
-http-client requires fpm version 0.8.x or later to build.
-Type:
+The `http` package uses **fpm** as the build system. Make sure you have fpm `version 0.8.x` or later installed. To build the library, execute the following command within the project directory:
 
 ```
 fpm build
 ```
-
-To run the examples, type:
+### **Run examples**
+The http package provides example programs that demonstrate its usage. To run the examples, use the following command:
 
 ```
-fpm run --example
+fpm run --example <example name>
 ```
+Executing this command will execute the example programs, allowing you to see the package in action and understand how to utilize its features.
 
-To run the tests, type:
-
+### **Run tests**
+ The http package includes a test suite to ensure its functionality is working as expected. To run the tests, execute the following command:
 ```
 fpm test
 ```
+Running the tests will validate the behavior of the package and help identify any issues or regressions.
+
+### **Contributing guidelines**
+
+When contributing to the http Fortran package, please keep the following guidelines in mind:
+
+* Before making any substantial changes, it is recommended to open an issue to discuss the proposed changes and ensure they align with the project's goals.
+* Fork the repository and create a new branch for your contribution.
+* Ensure that your code adheres to the existing coding style and follows good software engineering practices.
+* Write clear and concise commit messages.
+* Make sure to test your changes and ensure they do not introduce regressions or break existing functionality.
+* Submit a pull request with your changes, providing a clear explanation of the problem you are solving and the approach you have taken.
+
+We appreciate your contributions and look forward to your valuable input in improving the http Fortran package.
+
+Happy coding!

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Get the code:
 git clone https://github.com/fortran-lang/http-client
 cd http-client
 ```
+Install curl development headers on Ubuntu
+```
+sudo apt install -y libcurl4-openssl-dev
+```
 
 Build the library using [fpm](https://fpm.fortran-lang.org).
 http-client requires fpm version 0.8.x or later to build.

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -4,16 +4,21 @@ program response_header
     implicit none
     type(response_type) :: response
     type(string_type), allocatable :: headers(:)
+    character(:), allocatable :: val
     integer :: i = 0
 
-    response = request(url='https://gorest.co.in/public/v2/todos')
+    response = request(url='https://jsonplaceholder.typicode.com/todos/1')
     if(.not. response%ok) then
-        print *,"Error message : ", response%err_msg
+        print *,'Error message : ', response%err_msg
     else
+        print *, '===========Response header value by passing string_type============'
         headers = response%header_keys()
         do i = 1, size(headers)
-            print *,headers(i), ": ", response%header_value(headers(i))
+            print *, headers(i), ': ', response%header_value(headers(i))
         end do
+        print *, '===========Response header value by passing characters============'
+        val = response%header_value('date')
+        print *, 'date', ' : ',val
     end if
 
 end program response_header

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -1,9 +1,9 @@
 program response_header
-    use stdlib_string_type
+    use stdlib_string_type, only: string_type, write(formatted)
     use http, only: response_type, request, header_type
     implicit none
     type(response_type) :: response
-    type(string_type), allocatable :: headers(:)
+    type(string_type), allocatable :: header_keys(:)
     type(header_type) :: req_header
     character(:), allocatable :: val
     integer :: i = 0
@@ -19,11 +19,10 @@ program response_header
         print *,'Error message : ', response%err_msg
     else
         print *, '=========== Response header value by passing string_type ============'
-        ! headers is array of header key
-        headers = response%header%keys()
-        do i = 1, size(headers)
-            val = response%header%value(headers(i))
-            print *, headers(i), ': ', val
+        header_keys = response%header%keys()
+        do i = 1, size(header_keys)
+            val = response%header%value(header_keys(i))
+            print *, header_keys(i), ': ', val
         end do
         print *, '=========== Response header value by passing characters ============'
         val = response%header%value('date')

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -9,21 +9,25 @@ program response_header
     integer :: i = 0
 
     ! setting request header
-    call req_header%set_header('h1', 'v1')
-    call req_header%set_header('h2', 'v2')
-    call req_header%set_header('h3', 'v3')
+    call req_header%set('h1', 'v1')
+    call req_header%set('h2', 'v2')
+    call req_header%set('h3', 'v3')
+    call req_header%set('h4', 'v4')
 
-    response = request(url='https://jsonplaceholder.typicode.com/todos/1', header=req_header)
+    ! response = request(url='https://gorest.co.in/public/v2/todos/15726', header=req_header)
+    response = request(url='http://localhost:3002/', header=req_header)
     if(.not. response%ok) then
         print *,'Error message : ', response%err_msg
     else
-        print *, '===========Response header value by passing string_type============'
-        headers = response%header_keys()
+        print *, '=========== Response header value by passing string_type ============'
+        ! headers is array of header key
+        headers = response%header%keys()
         do i = 1, size(headers)
-            print *, headers(i), ': ', response%header_value(headers(i))
+            val = response%header%value(headers(i))
+            print *, headers(i), ': ', val
         end do
-        print *, '===========Response header value by passing characters============'
-        val = response%header_value('date')
+        print *, '=========== Response header value by passing characters ============'
+        val = response%header%value('date')
         print *, 'date', ' : ',val
     end if
 end program response_header

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -14,8 +14,7 @@ program response_header
     call req_header%set('h3', 'v3')
     call req_header%set('h4', 'v4')
 
-    ! response = request(url='https://gorest.co.in/public/v2/todos/15726', header=req_header)
-    response = request(url='http://localhost:3002/', header=req_header)
+    response = request(url='https://gorest.co.in/public/v2/todos/15726', header=req_header)
     if(.not. response%ok) then
         print *,'Error message : ', response%err_msg
     else

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -1,25 +1,18 @@
 program response_header
-    use fhash, only: fhash_tbl_t, key => fhash_key, fhash_iter_t, fhash_key_t
+    use stdlib_string_type
     use http, only: response_type, request
     implicit none
-    
-    type(fhash_iter_t) :: iter
-    class(fhash_key_t), allocatable :: ikey
-    class(*), allocatable :: idata
     type(response_type) :: response
-    character(:), allocatable :: val
+    type(string_type), allocatable :: headers(:)
+    integer :: i = 0
 
     response = request(url='https://gorest.co.in/public/v2/todos')
     if(.not. response%ok) then
         print *,"Error message : ", response%err_msg
     else
-        print '(a)', '=================Response Header in string=================='
-        print '(a)',  response%header_string
-        print '(a)', '=================Response Header in hash table=============='
-        iter = fhash_iter_t(response%header)
-        do while(iter%next(ikey,idata))
-            call response%header%get(key(ikey%to_string()),val)
-            print '(a,": ",a)', ikey%to_string(), val
+        headers = response%header_keys()
+        do i = 1, size(headers)
+            print *,headers(i), ": ", response%header_value(headers(i))
         end do
     end if
 

--- a/example/response_header.f90
+++ b/example/response_header.f90
@@ -1,13 +1,19 @@
 program response_header
     use stdlib_string_type
-    use http, only: response_type, request
+    use http, only: response_type, request, header_type
     implicit none
     type(response_type) :: response
     type(string_type), allocatable :: headers(:)
+    type(header_type) :: req_header
     character(:), allocatable :: val
     integer :: i = 0
 
-    response = request(url='https://jsonplaceholder.typicode.com/todos/1')
+    ! setting request header
+    call req_header%set_header('h1', 'v1')
+    call req_header%set_header('h2', 'v2')
+    call req_header%set_header('h3', 'v3')
+
+    response = request(url='https://jsonplaceholder.typicode.com/todos/1', header=req_header)
     if(.not. response%ok) then
         print *,'Error message : ', response%err_msg
     else
@@ -20,5 +26,4 @@ program response_header
         val = response%header_value('date')
         print *, 'date', ' : ',val
     end if
-
 end program response_header

--- a/fpm.toml
+++ b/fpm.toml
@@ -21,3 +21,4 @@ source-form = "free"
 [dependencies]
 fortran-curl = {git = "https://github.com/interkosmos/fortran-curl.git"}
 fhash = { git = "https://github.com/LKedward/fhash.git" }
+stdlib = "*"

--- a/src/http.f90
+++ b/src/http.f90
@@ -3,4 +3,5 @@ module http
         HTTP_DELETE, HTTP_GET, HTTP_HEAD, HTTP_PATCH, HTTP_POST, HTTP_POST
     use http_response, only: response_type
     use http_client, only: request
+    use http_header, only : header_type
 end module http

--- a/src/http/http_client.f90
+++ b/src/http/http_client.f90
@@ -73,8 +73,11 @@ contains
     function client_get_response(this) result(response)
         class(client_type), intent(inout) :: this
         type(response_type), target :: response
-        type(c_ptr) :: curl_ptr = c_null_ptr, header_list_ptr = c_null_ptr
+        type(c_ptr) :: curl_ptr,  header_list_ptr
         integer :: rc, i
+        
+        curl_ptr = c_null_ptr
+        header_list_ptr = c_null_ptr
         
         ! logic for populating response using fortran-curl
         response%url = this%request%url

--- a/src/http/http_header.f90
+++ b/src/http/http_header.f90
@@ -1,0 +1,23 @@
+module http_header
+    use iso_c_binding
+    use curl
+    implicit none
+    private
+    public :: header_type
+    type :: header_type
+        type(c_ptr) :: header_list_ptr = c_null_ptr
+        integer :: header_count = 0
+    contains
+        procedure :: set_header
+    end type header_type
+contains
+    subroutine set_header(this, h_key, h_val)
+        class(header_type), intent(inout) :: this
+        character(*), intent(in) :: h_key, h_val
+        character(:), allocatable :: final_header_string
+
+        final_header_string = h_key // ':' // h_val // c_null_char
+        this%header_list_ptr = curl_slist_append(this%header_list_ptr, final_header_string)
+        this%header_count = this%header_count + 1
+    end subroutine set_header
+end module http_header

--- a/src/http/http_header.f90
+++ b/src/http/http_header.f90
@@ -7,7 +7,7 @@ module http_header
     private
     public :: header_type
     type :: header_type
-        type(fhash_tbl_t), private :: header_fhash
+        type(fhash_tbl_t), private :: header
         type(string_type), private, allocatable :: header_key(:)
         integer :: header_count = 0
     contains
@@ -16,17 +16,17 @@ module http_header
         procedure :: header_string_type_key
         procedure :: header_char_key
         generic :: value => header_string_type_key, header_char_key
-        procedure :: set => update_header_fhash
+        procedure :: set => update_header
     end type header_type
 contains
-    subroutine update_header_fhash(this, h_key, h_val)
+    subroutine update_header(this, h_key, h_val)
         class(header_type), intent(inout) :: this
         character(*), intent(in) :: h_key, h_val
         if(len_trim(h_key) > 0 .and.  len_trim(h_val) > 0) then
-            call this%header_fhash%set(key(h_key), value=h_val)
+            call this%header%set(key(h_key), value=h_val)
             this%header_count = this%header_count + 1
         end if
-    end subroutine update_header_fhash
+    end subroutine update_header
 
     subroutine set_header_key(this)
         class(header_type), intent(inout) :: this
@@ -37,7 +37,7 @@ contains
         integer :: i
         i = 1
         allocate(this%header_key(this%header_count))
-        iter = fhash_iter_t(this%header_fhash)
+        iter = fhash_iter_t(this%header)
         do while(iter%next(ikey,idata) .and. i <= this%header_count)
             this%header_key(i) = string_type(trim(ikey%to_string()))
             i = i + 1
@@ -54,8 +54,8 @@ contains
         class(header_type) :: this
         type(string_type) :: h_key
         character(:), allocatable :: header_value
-        if(len(h_key) /= 0) then
-            call this%header_fhash%get(key(char(h_key)),header_value)
+        if(len(h_key) > 0) then
+            call this%header%get(key(char(h_key)),header_value)
         else
             header_value = ''
         end if
@@ -65,8 +65,8 @@ contains
         class(header_type) :: this
         character(*) :: h_key
         character(:), allocatable :: header_value
-        if(len(h_key) /= 0) then
-            call this%header_fhash%get(key(h_key),header_value)
+        if(len(h_key) > 0) then
+            call this%header%get(key(h_key),header_value)
         else
             header_value = ''
         end if

--- a/src/http/http_header.f90
+++ b/src/http/http_header.f90
@@ -22,7 +22,7 @@ contains
     subroutine update_header_fhash(this, h_key, h_val)
         class(header_type), intent(inout) :: this
         character(*), intent(in) :: h_key, h_val
-        if(len(trim(h_key)) > 0 .and.  len(trim(h_val)) > 0) then
+        if(len_trim(h_key) > 0 .and.  len_trim(h_val) > 0) then
             call this%header_fhash%set(key(h_key), value=h_val)
             this%header_count = this%header_count + 1
         end if
@@ -34,7 +34,7 @@ contains
         class(fhash_key_t), allocatable :: ikey
         class(*), allocatable :: idata
         character(:), allocatable :: val
-        integer :: i = 1
+        integer :: i
         i = 1
         allocate(this%header_key(this%header_count))
         iter = fhash_iter_t(this%header_fhash)

--- a/src/http/http_request.f90
+++ b/src/http/http_request.f90
@@ -1,4 +1,6 @@
 module http_request
+    use, intrinsic :: iso_c_binding
+    use http_header, only : header_type
     implicit none
 
     private
@@ -17,6 +19,7 @@ module http_request
     type :: request_type
         character(len=:), allocatable :: url
         integer :: method
+        type(header_type) :: header
     end type request_type
 
 end module http_request

--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -16,16 +16,18 @@ module http_response
         type(fhash_tbl_t), private :: header_fhash
         type(string_type), private, allocatable :: header_key(:)
         integer, private :: header_count = 0
- 
+        
     contains
         procedure :: set_header_key
         procedure :: header_keys
-        procedure :: header_value
+        procedure :: header_string_type_key
+        procedure :: header_char_key
+        generic :: header_value => header_string_type_key, header_char_key
         procedure :: update_header_fhash
     end type response_type
     
 contains
-
+    
     subroutine update_header_fhash(this, h_key, h_val)
         class(response_type), intent(inout) :: this
         character(:), intent(in), allocatable :: h_key, h_val
@@ -43,7 +45,7 @@ contains
         allocate(this%header_key(this%header_count))
         iter = fhash_iter_t(this%header_fhash)
         do while(iter%next(ikey,idata))
-            this%header_key(i) = ikey%to_string()
+            this%header_key(i) = trim(ikey%to_string())
             i = i + 1
         end do
     end subroutine set_header_key
@@ -54,7 +56,7 @@ contains
         header_keys = this%header_key
     end function header_keys
 
-    function header_value(this, h_key)
+    function header_string_type_key(this, h_key) result(header_value)
         class(response_type) :: this
         type(string_type) :: h_key
         character(:), allocatable :: header_value
@@ -63,6 +65,17 @@ contains
         else
             header_value = ''
         end if
-    end function header_value
+    end function header_string_type_key
+
+    function header_char_key(this, h_key) result(header_value)
+        class(response_type) :: this
+        character(*) :: h_key
+        character(:), allocatable :: header_value
+        if(len(h_key) /= 0) then
+            call this%header_fhash%get(key(h_key),header_value)
+        else
+            header_value = ''
+        end if
+    end function header_char_key
 
 end module http_response

--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -1,7 +1,6 @@
 module http_response
     use, intrinsic :: iso_fortran_env, only: int64
-    use fhash, only: fhash_tbl_t, key => fhash_key, fhash_iter_t, fhash_key_t
-    use stdlib_string_type
+    use http_header, only : header_type
     implicit none
 
     private
@@ -13,69 +12,18 @@ module http_response
         integer :: status_code = 0
         integer(kind=int64) :: content_length = 0
         logical :: ok = .true.
-        type(fhash_tbl_t), private :: header_fhash
-        type(string_type), private, allocatable :: header_key(:)
-        integer, private :: header_count = 0
+        type(header_type) :: header
+        ! type(fhash_tbl_t), private :: header_fhash
+        ! type(string_type), private, allocatable :: header_key(:)
+        ! integer, private :: header_count = 0
         
-    contains
-        procedure :: set_header_key
-        procedure :: header_keys
-        procedure :: header_string_type_key
-        procedure :: header_char_key
-        generic :: header_value => header_string_type_key, header_char_key
-        procedure :: update_header_fhash
+    ! contains
+    !     procedure :: set_header_key
+    !     procedure :: header_keys
+    !     procedure :: header_string_type_key
+    !     procedure :: header_char_key
+    !     generic :: header_value => header_string_type_key, header_char_key
+    !     procedure :: update_header_fhash
     end type response_type
-    
-contains
-    
-    subroutine update_header_fhash(this, h_key, h_val)
-        class(response_type), intent(inout) :: this
-        character(:), intent(in), allocatable :: h_key, h_val
-        call this%header_fhash%set(key(h_key), value=h_val)
-        this%header_count = this%header_count + 1
-    end subroutine update_header_fhash
-
-    subroutine set_header_key(this)
-        class(response_type), intent(inout) :: this
-        type(fhash_iter_t) :: iter
-        class(fhash_key_t), allocatable :: ikey
-        class(*), allocatable :: idata
-        character(:), allocatable :: val
-        integer :: i = 1
-        allocate(this%header_key(this%header_count))
-        iter = fhash_iter_t(this%header_fhash)
-        do while(iter%next(ikey,idata))
-            this%header_key(i) = trim(ikey%to_string())
-            i = i + 1
-        end do
-    end subroutine set_header_key
-
-    function header_keys(this) 
-        class(response_type), intent(in) :: this
-        type(string_type), allocatable :: header_keys(:)
-        header_keys = this%header_key
-    end function header_keys
-
-    function header_string_type_key(this, h_key) result(header_value)
-        class(response_type) :: this
-        type(string_type) :: h_key
-        character(:), allocatable :: header_value
-        if(len(h_key) /= 0) then
-            call this%header_fhash%get(key(char(h_key)),header_value)
-        else
-            header_value = ''
-        end if
-    end function header_string_type_key
-
-    function header_char_key(this, h_key) result(header_value)
-        class(response_type) :: this
-        character(*) :: h_key
-        character(:), allocatable :: header_value
-        if(len(h_key) /= 0) then
-            call this%header_fhash%get(key(h_key),header_value)
-        else
-            header_value = ''
-        end if
-    end function header_char_key
 
 end module http_response

--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -13,17 +13,6 @@ module http_response
         integer(kind=int64) :: content_length = 0
         logical :: ok = .true.
         type(header_type) :: header
-        ! type(fhash_tbl_t), private :: header_fhash
-        ! type(string_type), private, allocatable :: header_key(:)
-        ! integer, private :: header_count = 0
-        
-    ! contains
-    !     procedure :: set_header_key
-    !     procedure :: header_keys
-    !     procedure :: header_string_type_key
-    !     procedure :: header_char_key
-    !     generic :: header_value => header_string_type_key, header_char_key
-    !     procedure :: update_header_fhash
     end type response_type
 
 end module http_response

--- a/test/test_get.f90
+++ b/test/test_get.f90
@@ -1,15 +1,13 @@
 program test_get
     use iso_fortran_env, only: stderr => error_unit
-    use fhash, only:  key => fhash_key, fhash_iter_t, fhash_key_t
+    use stdlib_string_type
     use http, only : response_type, request
     implicit none
     type(response_type) :: res
     character(:), allocatable :: msg, original_content
     logical :: ok = .true.
+    type(string_type), allocatable :: header_array(:)
 
-    type(fhash_iter_t) :: iter
-    class(fhash_key_t), allocatable :: ikey
-    class(*), allocatable :: idata
     integer :: header_counter = 0, original_header_count = 19
 
     original_content = '{"id":15726,"user_id":2382773,&
@@ -43,11 +41,8 @@ program test_get
         msg = msg // 'test case 3, '
     end if
 
-    iter = fhash_iter_t(res%header)
-    do while(iter%next(ikey,idata))
-        header_counter = header_counter + 1
-    end do
-
+    header_array = res%header_keys()
+    header_counter = size(header_array)
     if (header_counter /= original_header_count) then
         ok = .false.
         msg = msg // 'test case 4, '

--- a/test/test_get.f90
+++ b/test/test_get.f90
@@ -1,12 +1,13 @@
 program test_get
     use iso_fortran_env, only: stderr => error_unit
     use stdlib_string_type
-    use http, only : response_type, request
+    use http, only : response_type, request, header_type
     implicit none
     type(response_type) :: res
     character(:), allocatable :: msg, original_content
     logical :: ok = .true.
     type(string_type), allocatable :: header_array(:)
+    type(header_type) :: request_header
 
     integer :: header_counter = 0, original_header_count = 19
 
@@ -15,7 +16,13 @@ program test_get
     &"due_on":"2023-06-09T00:00:00.000+05:30",&
     &"status":"completed"}'
 
-    res = request(url='https://gorest.co.in/public/v2/todos/15726')
+    ! setting request header
+    call request_header%set_header('header-1', 'value-1')
+    call request_header%set_header('header-2', 'value-2')
+    call request_header%set_header('header-3', 'value-3')
+
+
+    res = request(url='https://gorest.co.in/public/v2/todos/15726', header=request_header)
     
     msg = 'test_get: '
     if (.not. res%ok) then

--- a/test/test_get.f90
+++ b/test/test_get.f90
@@ -17,9 +17,9 @@ program test_get
     &"status":"completed"}'
 
     ! setting request header
-    call request_header%set_header('header-1', 'value-1')
-    call request_header%set_header('header-2', 'value-2')
-    call request_header%set_header('header-3', 'value-3')
+    call request_header%set('header-1', 'value-1')
+    call request_header%set('header-2', 'value-2')
+    call request_header%set('header-3', 'value-3')
 
 
     res = request(url='https://gorest.co.in/public/v2/todos/15726', header=request_header)
@@ -48,7 +48,7 @@ program test_get
         msg = msg // 'test case 3, '
     end if
 
-    header_array = res%header_keys()
+    header_array = res%header%keys()
     header_counter = size(header_array)
     if (header_counter /= original_header_count) then
         ok = .false.


### PR DESCRIPTION
### Making Header access more [user friendly](https://github.com/fortran-lang/http-client/issues/11#issuecomment-1572283627) and [Performing all cURL related tasks in a single function or subroutine](https://github.com/fortran-lang/http-client/issues/20#issuecomment-1575581808)
* Rename the `response_type` `header` to `header_fhash` and make it private.
* Remove the `header_string`, find it redundant
* Add stdlib as a dependency
* Added derived type `header_type`
* Remove curl_ptr and header_list_ptr from derived types.
* Add installation of libcurl in linux
* Update the tests and example files accordingly. 