### PR TITLE
Add functionality for sending files via HTTP POST requests.

### DIFF
--- a/example/get.f90
+++ b/example/get.f90
@@ -5,7 +5,7 @@ program get_request
     implicit none
     type(response_type) :: response
 
-    response = request(url='https://jsonplaceholder.typicode.com/todos/1')
+    response = request(url='https://httpbin.org/get')
     if(.not. response%ok) then
         print *,'Error message : ', response%err_msg
     else

--- a/example/post.f90
+++ b/example/post.f90
@@ -7,7 +7,7 @@ program post_request
     character(:), allocatable :: json_data
     type(header_type), allocatable :: req_header(:)
 
-    req_header = [header_type('Content-Type', 'applicaiton/json')]
+    req_header = [header_type('Content-Type', 'application/json')]
 
     ! JSON data we want to send
     json_data = '{"name":"Jhon","role":"developer"}'

--- a/example/post_file.f90
+++ b/example/post_file.f90
@@ -1,0 +1,26 @@
+! program post_file
+!     ! This program demonstrates sending File using POST request.
+!     use http, only: response_type, request, HTTP_POST, header_type, form_type, file_type
+!     implicit none
+!     type(response_type) :: response
+!     type(header_type), allocatable :: req_header(:)
+!     type(form_type), allocatable :: form_data(:)
+!     type(file_type) :: file_data
+
+!     form_data = [form_type('param1', 'value1'), form_type('param2', 'value2')]
+!     
+!     ! change file fileld name and file path as per requirement
+!     file_data = file_type('<file_field_name>', '/path/to/file.txt')
+    
+!     response = request(url='https://example.com/post/file', method=HTTP_POST, form=form_data, file=file_data)
+   
+!     if(.not. response%ok) then
+!         print *,'Error message : ', response%err_msg
+!     else
+!         print *, 'Response Code    : ', response%status_code
+!         print *, 'Response Length  : ', response%content_length
+!         print *, 'Response Method  : ', response%method
+!         print *, 'Response Content : ', response%content
+!     end if
+
+! end program post_file

--- a/example/post_form_data.f90
+++ b/example/post_form_data.f90
@@ -1,0 +1,23 @@
+program post_form_data
+    ! This program demonstrates sending Form data using POST request and printing the
+    ! status, length of the body, method, and the body of the response.
+    use http, only: response_type, request, HTTP_POST, header_type, form_type
+    implicit none
+    type(response_type) :: response
+    type(header_type), allocatable :: req_header(:)
+    type(form_type), allocatable :: form_data(:)
+
+    form_data = [form_type('param1', 'value1'), form_type('param2', 'value2')]
+
+    response = request(url='https://httpbin.org/post', method=HTTP_POST, form=form_data)
+   
+    if(.not. response%ok) then
+        print *,'Error message : ', response%err_msg
+    else
+        print *, 'Response Code    : ', response%status_code
+        print *, 'Response Length  : ', response%content_length
+        print *, 'Response Method  : ', response%method
+        print *, 'Response Content : ', response%content
+    end if
+
+end program post_form_data

--- a/src/http.f90
+++ b/src/http.f90
@@ -4,4 +4,5 @@ module http
     use http_response, only: response_type
     use http_client, only: request
     use http_header, only : header_type
+    use http_form, only : form_type
 end module http

--- a/src/http.f90
+++ b/src/http.f90
@@ -5,4 +5,5 @@ module http
     use http_client, only: request
     use http_header, only : header_type
     use http_form, only : form_type
+    use http_file, only : file_type
 end module http

--- a/src/http/http_client.f90
+++ b/src/http/http_client.f90
@@ -1,7 +1,16 @@
 module http_client
+
+    !! This module contains the definition of a client_type derived type, which is responsible 
+    !! for making HTTP requests.
+    !!
+    !! The client_type derived type takes a request_type object as input and uses it to make 
+    !! an HTTP request. It returns a response_type object representing the response to the request.
+    !!
+    !! This module uses the Fortran-curl package under the hood to make actual HTTP requests.
+
     use iso_fortran_env, only: int64
     use iso_c_binding, only: c_associated, c_f_pointer, c_funloc, c_loc, &
-        c_null_char, c_null_ptr, c_ptr, c_size_t
+        c_null_ptr, c_ptr, c_size_t
     use curl, only: c_f_str_ptr, curl_easy_cleanup, curl_easy_getinfo, &
         curl_easy_init, curl_easy_perform, curl_easy_setopt, &
         curl_easy_strerror, curl_slist_append, CURLE_OK, &
@@ -37,14 +46,31 @@ module http_client
     
 contains
     ! Constructor for request_type type.
+    ! This function creates a new request_type object and sets its URL, HTTP method, request headers, 
+    ! request data, and form data fields based on the input arguments. If the header argument is not 
+    ! provided, a default user-agent header is set to fortran-http/0.1.0. The function then creates a 
+    ! new client_type object using the request object as a parameter and sends the request to the server
+    ! using the client_get_response method. The function returns the response_type object containing the
+    ! server's response.
     function new_request(url, method, header, data, form) result(response)
+        !! This function creates a new HTTP request object of the request_type type and sends 
+        !! the request to the server using the client_type object. The function takes the URL, 
+        !! HTTP method, request headers, request data, and form data as input arguments and returns 
+        !! a response_type object containing the server's response.
         integer, intent(in), optional :: method
+            !! An optional integer argument that specifies the HTTP method to use for the request. 
+            !! The default value is 1, which corresponds to the HTTP_GET method.
         character(len=*), intent(in) :: url
+            !! An character(len=*) argument that specifies the URL of the server.
         character(len=*), intent(in), optional :: data
+            !! An optional character(len=*) argument that specifies the data to send in the request body.
         type(header_type), intent(in), optional :: header(:)
+            !! An optional array of header_type objects that specifies the request headers to send to the server.
         type(form_type), intent(in), optional :: form(:)
-        type(request_type) :: request
+            !! An optional array of form_type objects that specifies the form data to send in the request body.
         type(response_type) :: response
+            !! A response_type object containing the server's response.
+        type(request_type) :: request
         type(client_type) :: client
         integer :: i
 
@@ -81,16 +107,27 @@ contains
     end function new_request
 
     ! Constructor for client_type type.
+    ! This function creates a new client_type object and sets its request field to the input request 
+    ! object. The resulting client_type object can be used to send the HTTP request to the server 
+    ! using the client_get_response method.
     function new_client(request) result(client)
+        !! This function creates a new client_type object and sets its request field 
+        !! based on the input request_type object.
         type(request_type), intent(in) :: request
+            !! An in argument of the request_type type that specifies the HTTP request to send.
         type(client_type) :: client
+            !! A client_type object containing the request field set to the input request object.
 
         client%request = request
     end function new_client
 
     function client_get_response(this) result(response)
+        !! This function sends an HTTP request to a server using the libcurl library and returns the 
+        !! server's response as a response_type object.
         class(client_type), intent(inout) :: this
+            !! An inout argument of the client_type class that specifies the HTTP request to send.
         type(response_type), target :: response
+            !! A response_type object containing the server's response.
         type(c_ptr) :: curl_ptr,  header_list_ptr
         integer :: rc, i
         
@@ -110,7 +147,7 @@ contains
         end if
 
         ! setting request URL
-        rc = curl_easy_setopt(curl_ptr, CURLOPT_URL, this%request%url // c_null_char)
+        rc = curl_easy_setopt(curl_ptr, CURLOPT_URL, this%request%url )
 
         ! setting request method
         rc = set_method(curl_ptr, this%request%method, response)
@@ -154,13 +191,27 @@ contains
       
     end function client_get_response
     
-    ! This function converts the request%form data into URL-encoded name-value pairs
-    ! and stores the result in the request%form_encoded_str variable. The resulting 
-    ! string is used in an HTTP request body with the application/x-www-form-urlencoded
-    !  content type to send data as name-value pairs.
+    ! This subroutine takes a request object containing a list of name-value pairs 
+    ! representing the form data. It iterates over the list and URL-encodes each 
+    ! name and value using the curl_easy_escape function, which replaces special 
+    ! characters with their corresponding escape sequences.
+    ! The encoded name-value pairs are concatenated into a single string, separated 
+    ! by '&' characters. The resulting string is stored in the form_encoded_str field
+    ! of the request object.
+    ! Finally, the subroutine checks if the Content-Type header is already set in the 
+    ! request object. If not, it sets the header to application/x-www-form-urlencoded,
+    ! indicating that the HTTP request body contains URL-encoded form data.
     subroutine prepare_form_encoded_str(curl_ptr, request) 
+        !! This subroutine converts the request%form data into URL-encoded name-value pairs
+        !! and stores the result in the request%form_encoded_str variable. The resulting
+        !! string is used as the HTTP request body with the application/x-www-form-urlencoded
+        !! content type to send data as name-value pairs.
         type(c_ptr), intent(out) :: curl_ptr
+            !! A C pointer type that is used in the curl_easy_escape function to escape 
+            !! special characters in the form data.
         type(request_type), intent(inout) :: request
+            !! An inout argument of the request_type type, which contains the form data to be
+            !! encoded and the form_encoded_str variable to store the result.
         integer :: i
         if(allocated(request%form)) then
             do i=1, size(request%form)
@@ -181,55 +232,83 @@ contains
         end if
     end subroutine prepare_form_encoded_str
 
+    ! This subroutine prepares a linked list of headers for an HTTP request using the libcurl library. 
+    ! The function takes an array of header_type objects that contain the key-value pairs of the headers 
+    ! to include in the request. The subroutine iterates over the array and constructs a string for each 
+    ! header in the format "key:value". The subroutine then appends each string to the linked list using 
+    ! the curl_slist_append function. The resulting linked list is returned via the header_list_ptr argument.
     subroutine prepare_request_header_ptr(header_list_ptr, req_headers)
+        !! This subroutine prepares a linked list of headers for an HTTP request using the libcurl library.
         type(c_ptr), intent(out) :: header_list_ptr
+            !! An out argument of type c_ptr that is allocated and set to point to a linked list of headers.
         type(header_type), allocatable, intent(in) :: req_headers(:)
+            !! An in argument of type header_type array that specifies the headers to include in the request.
         character(:), allocatable :: h_key, h_val, final_header_string
         integer :: i
 
         do i = 1, size(req_headers)
             h_key = req_headers(i)%key
             h_val = req_headers(i)%value
-            final_header_string = h_key // ':' // h_val // c_null_char
+            final_header_string = h_key // ':' // h_val 
             header_list_ptr = curl_slist_append(header_list_ptr, final_header_string)
         end do
     end subroutine prepare_request_header_ptr
 
     function set_method(curl_ptr, method, response) result(status)
+        !! This function sets the HTTP method for a curl handle based on the input method integer and returns
+        !! the status of the curl_easy_setopt function call.
         type(c_ptr), intent(out) :: curl_ptr
+            !! An out argument of type c_ptr that is set to point to a new curl handle.
         integer, intent(in) :: method
+            !! An in argument of type integer that specifies the HTTP method to use.
         type(response_type), intent(out) :: response
+            !! An out argument of type response_type that is updated with the HTTP method string.
         integer :: status
+            !! An integer value representing the status of the curl_easy_setopt function call.
 
         select case(method)
         case(1)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'GET' // c_null_char)
+            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'GET' )
             response%method = 'GET'
         case(2)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'HEAD' // c_null_char)
+            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'HEAD' )
             response%method = 'HEAD'
         case(3)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'POST' // c_null_char)
+            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'POST' )
             response%method = 'POST'
         case(4)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'PUT' // c_null_char)
+            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'PUT' )
             response%method = 'PUT'
         case(5)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'DELETE' // c_null_char)
+            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'DELETE' )
             response%method = 'DELETE'
         case(6)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'PATCH' // c_null_char)
+            status = curl_easy_setopt(curl_ptr, CURLOPT_CUSTOMREQUEST, 'PATCH' )
             response%method = 'PATCH'
         case default
             error stop 'Method argument can be either HTTP_GET, HTTP_HEAD, HTTP_POST, HTTP_PUT, HTTP_DELETE, HTTP_PATCH'
         end select
     end function set_method
 
+    ! This function sets the request body for a curl handle based on the input data and form_encoded_str 
+    ! strings and returns the status of the curl_easy_setopt function call. The function takes two input 
+    ! arguments, data and form_encoded_str, which represent the request body data as a raw string or in 
+    ! URL encoded form, respectively. The function then uses an if statement to set the request body using 
+    ! the curl_easy_setopt function call and the CURLOPT_POSTFIELDS and CURLOPT_POSTFIELDSIZE_LARGE options. 
+    ! The function returns an integer value representing the status of the curl_easy_setopt function call.
     function set_body(curl_ptr, data, form_encoded_str) result(status)
+        !! This function sets the request body for a curl handle based on the input data and form_encoded_str
+        !! strings and returns the status of the curl_easy_setopt function call.
         type(c_ptr), intent(out) :: curl_ptr
-        character(*), intent(in), target :: data, form_encoded_str
+            !! An out argument of type c_ptr that is set to point to a new curl handle.
+        character(*), intent(in), target :: data
+            !! An in argument of type character(*) that specifies the request body data.
+        character(*), intent(in), target :: form_encoded_str
+            !! An in argument of type character(*) that specifies the request body data in URL encoded form.
+        integer :: status
+            !! An integer value representing the status of the curl_easy_setopt function call.
+        integer :: i
 
-        integer :: status, i
         if(len(data) > 0) then
             status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDS, c_loc(data))
             status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDSIZE_LARGE, len(data, kind=int64))
@@ -239,12 +318,28 @@ contains
         end if
     end function set_body
 
+    ! This function is a callback function used by the libcurl library to handle HTTP responses. It is 
+    ! called for each chunk of data received from the server and appends the data to a response_type object. 
+    ! The function takes four input arguments: ptr, size, nmemb, and client_data. ptr is a pointer to the 
+    ! received data buffer, size specifies the size of each data element, nmemb specifies the number of data 
+    ! elements received, and client_data is a pointer to a response_type object. The function uses 
+    ! c_f_pointer to convert the C pointer to a Fortran pointer and appends the received data to the 
+    ! content field of the response_type object. The function returns an integer(kind=c_size_t) value 
+    ! representing the number of bytes received.
     function client_response_callback(ptr, size, nmemb, client_data) bind(c)
+        !! This function is a callback function used by the libcurl library to handle HTTP responses. 
+        !! It is called for each chunk of data received from the server and appends the data to a 
+        !! response_type object.
         type(c_ptr), intent(in), value :: ptr 
+            !! An in argument of type c_ptr that points to the received data buffer.
         integer(kind=c_size_t), intent(in), value :: size 
+            !! An in argument of type integer(kind=c_size_t) that specifies the size of each data element.
         integer(kind=c_size_t), intent(in), value :: nmemb
+            !! An in argument of type integer(kind=c_size_t) that specifies the number of data elements received.
         type(c_ptr), intent(in), value :: client_data
+            !!  An in argument of type c_ptr that points to a response_type object.
         integer(kind=c_size_t) :: client_response_callback 
+            !! An integer(kind=c_size_t) value representing the number of bytes received.
         type(response_type), pointer :: response 
         character(len=:), allocatable :: buf
       
@@ -271,11 +366,19 @@ contains
     end function client_response_callback
 
     function client_header_callback(ptr, size, nmemb, client_data) bind(c)
+        !! This function is a callback function used by the libcurl library to handle HTTP headers. 
+        !! It is called for each header received from the server and stores the header in an array of 
+        !! header_type objects in a response_type object.
         type(c_ptr), intent(in), value :: ptr 
+            !! An in argument of type c_ptr that points to the received header buffer.
         integer(kind=c_size_t), intent(in), value :: size 
+            !!  An in argument of type integer(kind=c_size_t) that specifies the size of each header element.
         integer(kind=c_size_t), intent(in), value :: nmemb
+            !! An in argument of type integer(kind=c_size_t) that specifies the number of header elements received.
         type(c_ptr), intent(in), value :: client_data
+            !! An in argument of type c_ptr that points to a response_type object.
         integer(kind=c_size_t) :: client_header_callback 
+            !! An integer(kind=c_size_t) value representing the number of bytes received.
         type(response_type), pointer :: response 
         character(len=:), allocatable :: buf, h_key, h_value
         integer :: i
@@ -293,7 +396,7 @@ contains
         call c_f_str_ptr(ptr, buf, nmemb)
         if (.not. allocated(buf)) return
         
-        ! Parsing Header, and storing in hashmap
+        ! Parsing Header, and storing in array of header_type object
         i = index(buf, ':')
         if(i /= 0 .and. len(buf) > 2) then
             h_key = trim(buf(:i-1))

--- a/src/http/http_client.f90
+++ b/src/http/http_client.f90
@@ -10,19 +10,22 @@ module http_client
 
     use iso_fortran_env, only: int64
     use iso_c_binding, only: c_associated, c_f_pointer, c_funloc, c_loc, &
-        c_null_ptr, c_ptr, c_size_t
+        c_null_ptr, c_ptr, c_size_t, c_null_char
     use curl, only: c_f_str_ptr, curl_easy_cleanup, curl_easy_getinfo, &
         curl_easy_init, curl_easy_perform, curl_easy_setopt, &
         curl_easy_strerror, curl_slist_append, CURLE_OK, &
         CURLINFO_RESPONSE_CODE, CURLOPT_CUSTOMREQUEST, CURLOPT_HEADERDATA, &
         CURLOPT_HEADERFUNCTION, CURLOPT_HTTPHEADER, CURLOPT_URL, &
         CURLOPT_WRITEDATA, CURLOPT_WRITEFUNCTION, &
-        CURLOPT_POSTFIELDS, CURLOPT_POSTFIELDSIZE_LARGE, curl_easy_escape
+        CURLOPT_POSTFIELDS, CURLOPT_POSTFIELDSIZE_LARGE, curl_easy_escape, &
+        curl_mime_init, curl_mime_addpart, curl_mime_filedata,curl_mime_name, &
+        CURLOPT_MIMEPOST,curl_mime_data
     use stdlib_optval, only: optval
     use http_request, only: request_type
     use http_response, only: response_type
     use http_header, only: append_header, header_has_key, header_type
     use http_form, only: form_type
+    use http_file, only: file_type
     
     implicit none
 
@@ -52,7 +55,7 @@ contains
     ! new client_type object using the request object as a parameter and sends the request to the server
     ! using the client_get_response method. The function returns the response_type object containing the
     ! server's response.
-    function new_request(url, method, header, data, form) result(response)
+    function new_request(url, method, header, data, form, file) result(response)
         !! This function creates a new HTTP request object of the request_type type and sends 
         !! the request to the server using the client_type object. The function takes the URL, 
         !! HTTP method, request headers, request data, and form data as input arguments and returns 
@@ -68,6 +71,8 @@ contains
             !! An optional array of header_type objects that specifies the request headers to send to the server.
         type(form_type), intent(in), optional :: form(:)
             !! An optional array of form_type objects that specifies the form data to send in the request body.
+        type(file_type), intent(in), optional :: file
+            !! An optional file_type object that specifies the file data to send in the request body.
         type(response_type) :: response
             !! A response_type object containing the server's response.
         type(request_type) :: request
@@ -99,6 +104,11 @@ contains
         ! setting request form
         if(present(form)) then
             request%form = form
+        end if
+
+        ! setting request file
+        if(present(file)) then
+            request%file = file
         end if
 
         ! Populates the response 
@@ -156,7 +166,8 @@ contains
         call prepare_form_encoded_str(curl_ptr, this%request)
         
         ! setting request body
-        rc = set_body(curl_ptr, this%request%data, this%request%form_encoded_str)
+        rc = set_body(curl_ptr, this%request%header, this%request%data, &
+        this%request%form_encoded_str, this%request%form, this%request%file)
 
         ! prepare headers for curl
         call prepare_request_header_ptr(header_list_ptr, this%request%header)
@@ -198,9 +209,6 @@ contains
     ! The encoded name-value pairs are concatenated into a single string, separated 
     ! by '&' characters. The resulting string is stored in the form_encoded_str field
     ! of the request object.
-    ! Finally, the subroutine checks if the Content-Type header is already set in the 
-    ! request object. If not, it sets the header to application/x-www-form-urlencoded,
-    ! indicating that the HTTP request body contains URL-encoded form data.
     subroutine prepare_form_encoded_str(curl_ptr, request) 
         !! This subroutine converts the request%form data into URL-encoded name-value pairs
         !! and stores the result in the request%form_encoded_str variable. The resulting
@@ -225,10 +233,6 @@ contains
                     // '=' // curl_easy_escape(curl_ptr, request%form(i)%value, len(request%form(i)%value))
                 end if
             end do
-            ! setting the Content-Type header to application/x-www-form-urlencoded, used for sending form data
-            if (.not. header_has_key(request%header, 'Content-Type')) then
-                call append_header(request%header, 'Content-Type', 'application/x-www-form-urlencoded')
-            end if
         end if
     end subroutine prepare_form_encoded_str
 
@@ -290,31 +294,74 @@ contains
         end select
     end function set_method
 
-    ! This function sets the request body for a curl handle based on the input data and form_encoded_str 
-    ! strings and returns the status of the curl_easy_setopt function call. The function takes two input 
-    ! arguments, data and form_encoded_str, which represent the request body data as a raw string or in 
-    ! URL encoded form, respectively. The function then uses an if statement to set the request body using 
-    ! the curl_easy_setopt function call and the CURLOPT_POSTFIELDS and CURLOPT_POSTFIELDSIZE_LARGE options. 
-    ! The function returns an integer value representing the status of the curl_easy_setopt function call.
-    function set_body(curl_ptr, data, form_encoded_str) result(status)
-        !! This function sets the request body for a curl handle based on the input data and form_encoded_str
-        !! strings and returns the status of the curl_easy_setopt function call.
+    ! The set_body function determines the type of data to include in the request body 
+    ! based on the inputs provided. If data is provided, it is sent as the body of the 
+    ! request. If form is provided without a file, the form data is URL encoded and sent 
+    ! as the body of the request. If file is provided without form, the file is sent 
+    ! using a multipart/form-data header. If both form and file are provided, the file 
+    ! takes priority and the form data along with file is sent as part of the multipart/form-data 
+    ! body. If data, form, and file are all provided, only data is sent and the form and file 
+    ! inputs are ignored.
+    ! 
+    ! data -> data
+    ! form -> form
+    ! file -> file
+    ! data + form + file -> data
+    ! form + file -> form + file (in multipart/form-data)
+    ! 
+    ! Note : At a time only one file can be send
+    function set_body(curl_ptr, header, data, form_encoded_str, form, file) result(status)
+        !! The set_body function sets the request body for a curl handle based on the input data and 
+        !! form_encoded_str strings and returns the status of the curl_easy_setopt function call.
         type(c_ptr), intent(out) :: curl_ptr
             !! An out argument of type c_ptr that is set to point to a new curl handle.
         character(*), intent(in), target :: data
             !! An in argument of type character(*) that specifies the request body data.
         character(*), intent(in), target :: form_encoded_str
             !! An in argument of type character(*) that specifies the request body data in URL encoded form.
+        type(header_type), allocatable, intent(inout) :: header(:)
+            !! An allocatable array of header_type objects that specifies the request headers to send to the server.
+        type(form_type), allocatable, intent(in) :: form(:)
+            !! An allocatable array of form_type objects that specifies the form data to send in the request body.
+        type(file_type), intent(in) :: file
+            !! An in argument of type file_type that specifies the file data to send in the request body.
         integer :: status
             !! An integer value representing the status of the curl_easy_setopt function call.
         integer :: i
+        integer(kind=8) :: CURL_ZERO_TERMINATED = -1
+        type(c_ptr) :: mime_ptr, part_ptr
 
+        ! if only data is passed
         if(len(data) > 0) then
             status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDS, c_loc(data))
             status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDSIZE_LARGE, len(data, kind=int64))
+        ! if file is passsed
+        else if(len(file%name) > 0) then
+            mime_ptr = curl_mime_init(curl_ptr)
+            part_ptr = curl_mime_addpart(mime_ptr)
+            status = curl_mime_filedata(part_ptr, file%path)
+            status = curl_mime_name(part_ptr, file%name)
+            ! if both file and form are passed
+            if(len(form_encoded_str) > 0) then
+                do i=1, size(form)
+                    part_ptr = curl_mime_addpart(mime_ptr)
+                    status = curl_mime_data(part_ptr, form(i)%value, CURL_ZERO_TERMINATED)
+                    status = curl_mime_name(part_ptr, form(i)%name)
+                end do
+            end if
+            status = curl_easy_setopt(curl_ptr, CURLOPT_MIMEPOST, mime_ptr)
+            ! setting the Content-Type header to multipart/form-data, used for sending  binary data
+            if (.not. header_has_key(header, 'Content-Type')) then
+                call append_header(header, 'Content-Type', 'multipart/form-data')
+            end if
+        ! if only form is passed
         else if(len(form_encoded_str) > 0) then
             status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDS, c_loc(form_encoded_str))
             status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDSIZE_LARGE, len(form_encoded_str, kind=int64))    
+            ! setting the Content-Type header to application/x-www-form-urlencoded, used for sending form data
+            if (.not. header_has_key(header, 'Content-Type')) then
+                call append_header(header, 'Content-Type', 'application/x-www-form-urlencoded')
+            end if
         end if
     end function set_body
 

--- a/src/http/http_client.f90
+++ b/src/http/http_client.f90
@@ -1,4 +1,5 @@
 module http_client
+    use iso_fortran_env, only: int64
     use iso_c_binding, only: c_associated, c_f_pointer, c_funloc, c_loc, &
         c_null_char, c_null_ptr, c_ptr, c_size_t
     use curl, only: c_f_str_ptr, curl_easy_cleanup, curl_easy_getinfo, &
@@ -226,15 +227,15 @@ contains
 
     function set_body(curl_ptr, data, form_encoded_str) result(status)
         type(c_ptr), intent(out) :: curl_ptr
-        character(*), intent(in) :: data, form_encoded_str
+        character(*), intent(in), target :: data, form_encoded_str
 
         integer :: status, i
         if(len(data) > 0) then
-            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDS, data)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDSIZE_LARGE, len(data))
+            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDS, c_loc(data))
+            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDSIZE_LARGE, len(data, kind=int64))
         else if(len(form_encoded_str) > 0) then
-            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDS, form_encoded_str)
-            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDSIZE_LARGE, len(form_encoded_str))    
+            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDS, c_loc(form_encoded_str))
+            status = curl_easy_setopt(curl_ptr, CURLOPT_POSTFIELDSIZE_LARGE, len(form_encoded_str, kind=int64))    
         end if
     end function set_body
 

--- a/src/http/http_file.f90
+++ b/src/http/http_file.f90
@@ -1,0 +1,17 @@
+module http_file
+    !! The http_file module defines the file_type type, which is used
+    !! to store information about files to be sent in HTTP requests.
+    implicit none
+    private
+    public :: file_type
+
+    type :: file_type
+        !! A derived type used to store information about files to be 
+        !!sent in HTTP requests.
+        character(:), allocatable :: name
+        !! A character string that contains the name of the file.
+        character(:), allocatable :: path
+        !! A character string that contains the path of the file 
+        !! on the local system.
+    end type file_type
+end module http_file

--- a/src/http/http_form.f90
+++ b/src/http/http_form.f90
@@ -1,9 +1,15 @@
 module http_form
+    !! This module contains the definition of a form_type derived type, which represents a 
+    !!single field of an HTTP form.
     implicit none
     private
     public :: form_type
 
     type :: form_type
+    !! A derived type representing a single field of an HTTP form.
         character(:), allocatable :: name, value
+        !! The form_type derived type contains two character allocatable components: name and value. 
+        !! The name component represents the name of the field, while the value component represents 
+        !! the value of the field.
     end type form_type
 end module http_form

--- a/src/http/http_form.f90
+++ b/src/http/http_form.f90
@@ -1,0 +1,9 @@
+module http_form
+    implicit none
+    private
+    public :: form_type
+
+    type :: form_type
+        character(:), allocatable :: name, value
+    end type form_type
+end module http_form

--- a/src/http/http_request.f90
+++ b/src/http/http_request.f90
@@ -1,4 +1,5 @@
 module http_request
+    use http_form , only: form_type
     use http_header, only: header_type
     use stdlib_string_type, only: string_type, to_lower, operator(==), char
 
@@ -18,8 +19,9 @@ module http_request
 
     ! Request Type
     type :: request_type
-        character(len=:), allocatable :: url, data
+        character(len=:), allocatable :: url, data, form_encoded_str
         integer :: method
         type(header_type), allocatable :: header(:)
+        type(form_type), allocatable :: form(:)
     end type request_type
 end module http_request

--- a/src/http/http_request.f90
+++ b/src/http/http_request.f90
@@ -4,6 +4,7 @@ module http_request
     !! represents an HTTP request.
 
     use http_form , only: form_type
+    use http_file , only: file_type
     use http_header, only: header_type
     use stdlib_string_type, only: string_type, to_lower, operator(==), char
 
@@ -30,15 +31,23 @@ module http_request
     ! Request Type
     type :: request_type
     !! A derived type representing an HTTP request.
-        character(len=:), allocatable :: url, data, form_encoded_str
+        character(len=:), allocatable :: url
             !!  url: a character allocatable component representing the URL of the request.
+        character(len=:), allocatable :: data
             !! data: a character allocatable component representing the request data.
-            !! form_encoded_str: a character allocatable component representing the URL-encoded form data.
+        character(len=:), allocatable ::  form_encoded_str
+            !! form_encoded_str: a character allocatable component representing the 
+            !! URL-encoded form data.
         integer :: method
             !! an integer component representing the HTTP method of the request.
         type(header_type), allocatable :: header(:)
-            !! an allocatable array of header_type derived types representing the request headers.
+            !! an allocatable array of header_type derived types representing the request 
+            !! headers.
         type(form_type), allocatable :: form(:)
-            !! an allocatable array of form_type derived types representing the fields of an HTTP form.
+            !! an allocatable array of form_type derived types representing the fields of 
+            !! an HTTP form.
+        type(file_type) :: file
+            !! an derived type file_type used to store information about files to be 
+            !! sent in HTTP requests.
     end type request_type
 end module http_request

--- a/src/http/http_request.f90
+++ b/src/http/http_request.f90
@@ -1,4 +1,8 @@
 module http_request
+
+    !! This module contains the definition of a request_type derived type, which 
+    !! represents an HTTP request.
+
     use http_form , only: form_type
     use http_header, only: header_type
     use stdlib_string_type, only: string_type, to_lower, operator(==), char
@@ -10,18 +14,31 @@ module http_request
     public :: request_type
 
     ! HTTP methods:
+    ! An integer parameter representing the HTTP GET method.
     integer, parameter :: HTTP_GET = 1
+    ! An integer parameter representing the HTTP HEAD method.
     integer, parameter :: HTTP_HEAD = 2
+    ! An integer parameter representing the HTTP POST method.
     integer, parameter :: HTTP_POST = 3
+    ! An integer parameter representing the HTTP PUT method.
     integer, parameter :: HTTP_PUT = 4
+    ! An integer parameter representing the HTTP DELETE method.
     integer, parameter :: HTTP_DELETE = 5
+    ! An integer parameter representing the HTTP PATCH method.
     integer, parameter :: HTTP_PATCH = 6
 
     ! Request Type
     type :: request_type
+    !! A derived type representing an HTTP request.
         character(len=:), allocatable :: url, data, form_encoded_str
+            !!  url: a character allocatable component representing the URL of the request.
+            !! data: a character allocatable component representing the request data.
+            !! form_encoded_str: a character allocatable component representing the URL-encoded form data.
         integer :: method
+            !! an integer component representing the HTTP method of the request.
         type(header_type), allocatable :: header(:)
+            !! an allocatable array of header_type derived types representing the request headers.
         type(form_type), allocatable :: form(:)
+            !! an allocatable array of form_type derived types representing the fields of an HTTP form.
     end type request_type
 end module http_request

--- a/src/http/http_response.f90
+++ b/src/http/http_response.f90
@@ -1,4 +1,8 @@
 module http_response
+
+    !! This module contains the definition of a response_type derived type, which 
+    !! represents an HTTP response.
+
     use, intrinsic :: iso_fortran_env, only: int64
     use http_header, only: header_type, get_header_value
     use stdlib_string_type, only: string_type, to_lower, operator(==), char
@@ -11,10 +15,18 @@ module http_response
     ! Response Type
     type :: response_type
         character(len=:), allocatable :: url, content, method, err_msg
+            !! url: a character allocatable component representing the URL of the request that generated the response.
+            !! method: a character allocatable component representing the HTTP method used in the request.
+            !! content: a character allocatable component representing the content of the response.
+            !! err_msg: a character allocatable component representing an error message if the response was not successful.
         integer :: status_code = 0
+            !! An integer component representing the HTTP status code of the response
         integer(kind=int64) :: content_length = 0
+            !! An integer component representing the length of the response content.
         logical :: ok = .true.
+            !! A logical component that is true if the response was successful else false.
         type(header_type), allocatable :: header(:)
+            !! An allocatable array of header_type derived types representing the response headers.
     contains
         procedure :: header_value
     end type response_type

--- a/test/test_get.f90
+++ b/test/test_get.f90
@@ -5,19 +5,16 @@ program test_get
     implicit none
     type(response_type) :: res
     character(:), allocatable :: msg, original_content
-    character(2), allocatable :: number
     logical :: ok = .true.
     type(header_type), allocatable :: request_header(:)
-    integer :: i, passed_test_case, fail_test_case
+    integer :: i
 
-    passed_test_case = 0
-    fail_test_case = 0
-
-    original_content = '{"data":{"id":1,"email":"george.bluth@reqres.in",&
-    &"first_name":"George","last_name":"Bluth",&
-    &"avatar":"https://reqres.in/img/faces/1-image.jpg"},&
-    &"support":{"url":"https://reqres.in/#support-heading",&
-    &"text":"To keep ReqRes free, contributions towards server costs are appreciated!"}}'
+    original_content = '{"id":1,"title":"iPhone 9","description":"An apple mobile which is nothing like &
+    apple","price":549,"discountPercentage":12.96,"rating":4.69,"stock":94,"brand":"Apple","category":&
+    "smartphones","thumbnail":"https://i.dummyjson.com/data/products/1/thumbnail.jpg","images":&
+    ["https://i.dummyjson.com/data/products/1/1.jpg","https://i.dummyjson.com/data/products/1/2.jpg",&
+    "https://i.dummyjson.com/data/products/1/3.jpg","https://i.dummyjson.com/data/products/1/4.jpg",&
+    "https://i.dummyjson.com/data/products/1/thumbnail.jpg"]}'
 
     ! setting request header
     request_header = [ &
@@ -27,7 +24,8 @@ program test_get
       header_type('User-Agent', 'my user agent') &
       ]
 
-    res = request(url='https://reqres.in/api/users/1', header=request_header)
+    ! res = request(url='https://reqres.in/api/users/1', header=request_header)
+    res = request(url='https://dummyjson.com/products/1', header=request_header)
     
     msg = 'test_get: '
    
@@ -42,9 +40,6 @@ program test_get
     if (res%status_code /= 200) then
         ok = .false.
         print '(a)', 'Failed : Status Code Validation'
-        fail_test_case = fail_test_case + 1
-    else
-        passed_test_case = passed_test_case + 1
     end if
    
     ! Content Length Validation
@@ -52,41 +47,29 @@ program test_get
         len(res%content) /= len(original_content)) then
         ok = .false.
         print '(a)', 'Failed : Content Length Validation'
-        fail_test_case = fail_test_case + 1
-    else 
-        passed_test_case = passed_test_case + 1
     end if
 
     ! Content Validation
     if (res%content /= original_content) then
         ok = .false.
         print '(a)', 'Failed : Content Validation'
-        fail_test_case = fail_test_case + 1
-    else 
-        passed_test_case = passed_test_case + 1
     end if
 
     ! Header Size Validation
-    if (size(res%header) /= 14 .and. size(res%header) /= 15) then
+    if (size(res%header) /= 16) then
         ok = .false.
         print '(a)', 'Failed : Header Size Validation'
-        fail_test_case = fail_test_case + 1
-    else 
-        passed_test_case = passed_test_case + 1
     end if
 
     ! Header Value Validation
     if (res%header_value('content-type') /= 'application/json; charset=utf-8') then
         ok = .false.
         print '(a)', 'Failed : Header Value Validation'
-        fail_test_case = fail_test_case + 1
-    else 
-        passed_test_case = passed_test_case + 1
     end if
 
     if (.not. ok) then 
-        write(stderr, '(a i2 a i2 a)'), msg, fail_test_case,'/',fail_test_case+passed_test_case,&
-        & ' Test Case Failed'
+        msg = msg // 'Test Case Failed'
+        write(stderr, '(a)'), msg
         error stop 1
     else
         msg = msg // 'All tests passed.'

--- a/test/test_post.f90
+++ b/test/test_post.f90
@@ -1,0 +1,54 @@
+program test_post
+    use iso_fortran_env, only: stderr => error_unit
+    use http, only: request, header_type, HTTP_POST, response_type
+    implicit none
+    type(response_type) :: res
+    character(:), allocatable :: json_data, original_content, msg
+    type(header_type), allocatable :: req_header(:)
+    logical :: ok = .true.
+
+    original_content = '{"id":101,"title":"BMW","description":"A luxurious and high-performance vehicle"}'
+    req_header = [header_type('Content-Type', 'application/json')]
+
+    json_data = '{"title":"BMW","description":"A luxurious and high-performance vehicle"}'
+
+    res = request(url='https://dummyjson.com/products/add', method=HTTP_POST, data=json_data, header=req_header)
+    
+    msg = 'test_post: '
+
+    if (.not. res%ok) then
+        ok = .false.
+        msg = msg // res%err_msg
+        write(stderr, '(a)') msg
+        error stop 1
+    end if
+
+    ! Status Code Validation
+    if (res%status_code /= 200) then
+        ok = .false.
+        print '(a)', 'Failed : Status Code Validation'
+    end if
+
+    ! Content Length Validation
+    if (res%content_length /= len(original_content) .or. &
+        len(res%content) /= len(original_content)) then
+        ok = .false.
+        print '(a)', 'Failed : Content Length Validation'
+    end if
+
+    ! Content Validation
+    if (res%content /= original_content) then
+        ok = .false.
+        print '(a)', 'Failed : Content Validation'
+    end if
+
+    if (.not. ok) then 
+        msg = msg // 'Test Case Failed'
+        write(stderr, '(a)'), msg
+        error stop 1
+    else
+        msg = msg // 'All tests passed.'
+        print '(a)', msg 
+    end if
+
+end program test_post


### PR DESCRIPTION
I have done some changes in `set_body` function to send files also : 

The `set_body` function determines the type of data to include in the request body  based on the inputs provided. If `data` is provided, it is sent as the body of the  request. If `form` is provided without a `file`, the form data is URL encoded and sent as the body of the request. If `file` is provided without `form`, the `file` is sent using a multipart/form-data header. If both `form` and `file` are provided, the `file` takes priority and the `form` along with `file` is sent as part of the multipart/form-data body. If `data`, `form`, and `file` are all provided, only `data` is sent and the `form` and `file` inputs are ignored.