### PR TITLE
Fix bugs discovered by Intel OneAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ fpm test
 ```
 Running the tests will validate the behavior of the package and help identify any issues or regressions.
 
+### Supported compilers
+
+http-client is known to work with the following compilers:
+
+* GFortran 11 & 12 (tested in CI)
+* Intel OneAPI ifx v2023.1.0 and ifort classic v2021.9.0
+
 ### **Contributing guidelines**
 
 When contributing to the http Fortran package, please keep the following guidelines in mind:

--- a/src/http/http_client.f90
+++ b/src/http/http_client.f90
@@ -354,7 +354,7 @@ contains
                 call append_pair(request%header, 'Content-Type', 'application/x-www-form-urlencoded')
             end if
         else
-            ! curl_easy_setopt was not called so set status to zero.
+            ! No curl function was called so set status to zero.
             status = 0
         end if
         

--- a/src/http/http_client.f90
+++ b/src/http/http_client.f90
@@ -319,11 +319,11 @@ contains
         type(c_ptr) :: mime_ptr, part_ptr
 
         ! if only data is passed
-        if(len(request%data) > 0) then
+        if (allocated(request%data)) then
             status = set_postfields(curl_ptr, request%data)
         
         ! if file is passsed
-        else if(len(request%file%name) > 0) then
+        else if (allocated(request%file)) then
             mime_ptr = curl_mime_init(curl_ptr)
             part_ptr = curl_mime_addpart(mime_ptr)
             status = curl_mime_filedata(part_ptr, request%file%value)
@@ -345,7 +345,7 @@ contains
             end if
         
         ! if only form is passed
-        else if(allocated(request%form)) then
+        else if (allocated(request%form)) then
             request%form_encoded_str = prepare_form_encoded_str(curl_ptr, request)
             status = set_postfields(curl_ptr, request%form_encoded_str)
            
@@ -353,6 +353,9 @@ contains
             if (.not. pair_has_name(request%header, 'Content-Type')) then
                 call append_pair(request%header, 'Content-Type', 'application/x-www-form-urlencoded')
             end if
+        else
+            ! curl_easy_setopt was not called so set status to zero.
+            status = 0
         end if
         
     end function set_body

--- a/src/http/http_request.f90
+++ b/src/http/http_request.f90
@@ -36,7 +36,7 @@ module http_request
             !! An Array of request headers.
         type(pair_type), allocatable :: form(:)
             !! An array of fields in an HTTP form.
-        type(pair_type) :: file
+        type(pair_type), allocatable :: file
             !! Used to store information about files to be sent in HTTP requests.
     end type request_type
 end module http_request


### PR DESCRIPTION
http-client now builds and passes tests with Intel OneAPI (both ifx (IFX) 2023.1.0 20230320 and ifort (IFORT) 2021.9.0 20230302) with this PR.

Before this PR, a few tests were failing in cases where `request % data` or `request % file` were referenced in `set_body` while not allocated. This PR fixes it by checking their allocation status rather then their length.

