### PR TITLE
Bump fortran-curl version to 0.6.0

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -19,5 +19,5 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortran-curl = {git = "https://github.com/interkosmos/fortran-curl.git", tag = "0.5.0"}
+fortran-curl = {git = "https://github.com/interkosmos/fortran-curl.git", tag = "0.6.0"}
 stdlib = "*"


### PR DESCRIPTION
Should fix #58.

We should add macos workflow to CI in a separate pR.