### PR TITLE
Add forcompile project to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ An fpm example project that displays the latest xkcd comic inside an X window.
 As a limitation, only images in PNG format are supported.
 The alt text will be printed to console.
 * [foropenai](https://github.com/gha3mi/foropenai): A Fortran library to access the OpenAI API.
-
 * [fortelegram-bot](https://github.com/vypivshiy/fortelegram-bot): An Example of simple telegram bot
-
+* [forcompile](https://github.com/gha3mi/forcompile): A Fortran library to access the Compiler Explorer API.
+  
 If you're using http-client in your Fortran project and would like to be
 included on this list, we welcome you to contribute by creating a pull request
 (PR) and adding your project details. 


### PR DESCRIPTION
Hello,

I have added the `ForCompile` project to the README.

`ForCompile` utilizes the `http-client` to access the `Compiler Explorer` API.

Best,
Ali